### PR TITLE
feat: initial commit with export LWC component

### DIFF
--- a/export/export.html
+++ b/export/export.html
@@ -1,0 +1,10 @@
+<template>
+        <div class="slds-p-around_medium">
+            <lightning-button 
+                label="Export"
+                variant="brand"
+                onclick={handleExport}
+                icon-name="utility:download">
+            </lightning-button>
+        </div>
+</template>

--- a/export/export.js
+++ b/export/export.js
@@ -1,0 +1,50 @@
+import { LightningElement, api } from 'lwc';
+
+export default class Export extends LightningElement {
+    @api records; 
+    @api fileName; 
+
+    handleExport() {
+        if (!this.records || this.records.length === 0) {
+            alert('No data available to export.');
+            return;
+        }
+
+        // Auto-detect fields from the first record
+        const fields = Object.keys(this.records[0]);
+        const csvString = this.convertArrayToCSV(this.records, fields);
+
+        // Create temporary link for download
+        const element = document.createElement('a');
+        element.href = 'data:text/csv;charset=utf-8,' + encodeURI(csvString);
+        element.target = '_self';
+        element.download = `${this.fileName || 'Export'}.csv`; 
+        document.body.appendChild(element);
+        element.click();
+    }
+
+    convertArrayToCSV(objArray) {
+        // exclude attributes
+        const fields = Object.keys(objArray[0]).filter(f => f !== 'attributes');
+        let csvString = fields.join(',') + '\n';
+    
+        objArray.forEach(record => {
+            const row = fields.map(field => {
+                let value = record[field];
+    
+                if (value === null || value === undefined) {
+                    value = '';
+                } else if (typeof value === 'object') {
+                    // Flatten nested objects to JSON string or pick a property like Name
+                    value = JSON.stringify(value);
+                }
+    
+                return `"${String(value).replace(/"/g, '""')}"`; // escape quotes
+            }).join(',');
+            csvString += row + '\n';
+        });
+    
+        return csvString;
+    }
+    
+}

--- a/export/export.js-meta.xml
+++ b/export/export.js-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>59.0</apiVersion>
+    <isExposed>false</isExposed>
+</LightningComponentBundle>


### PR DESCRIPTION
This pull request adds a new Lightning Web Component (LWC) named `export` that allows users to dynamically export Salesforce records from any standard or custom object into CSV format.

### Key Features:
- Works with **any Salesforce object**.
- **Automatically retrieves all fields** from the object.
- Exports records to a **CSV file** with an optional custom file name.
- Lightweight and fully **reusable** across multiple pages.
- Simple integration using `<c-export records={records} file-name={fileName}></c-export>`.

### Benefits:
- Quick ad-hoc export without creating reports.
- Share Salesforce data with non-Salesforce users.
- Debug and review object data easily.

No existing components or files are modified — this is a **new component addition**.
